### PR TITLE
Add additional param to pass arguments to exif

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,15 +15,23 @@ var command = require('shelly');
  * @api public
  */
 
-module.exports = function(file, execOpts, fn){
+module.exports = function(file, execOpts, commandOpts, fn){
   // rationalize options
   if(typeof execOpts === 'function') {
     fn = execOpts;
     execOpts = {};
+    commandOpts = '';
   }
+
+  if(typeof commandOpts === 'function') {
+    fn = commandOpts;
+    commandOpts = '';
+  }
+
   // REM : exiftool options http://www.sno.phy.queensu.ca/~phil/exiftool/exiftool_pod.html
   // -json : ask JSON output
-  var cmd = command('exiftool -json ?', file);
+  var cmd = command('exiftool -json '+commandOpts+' ? ', file);
+  console.log(cmd)
   exec(cmd, execOpts, function(err, str)
   {
     if(err) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(file, execOpts, commandOpts, fn){
   // REM : exiftool options http://www.sno.phy.queensu.ca/~phil/exiftool/exiftool_pod.html
   // -json : ask JSON output
   var cmd = command('exiftool -json '+commandOpts+' ? ', file);
-  console.log(cmd)
+  
   exec(cmd, execOpts, function(err, str)
   {
     if(err) {


### PR DESCRIPTION
Sometimes need to pass params to command line, for example for excuding some tags from output JSON or format dates.

This pull request is about that. Extra argument was added to function:

``` javascript
var arguments = '--PhotoshopThumbnail --ThumbnailImage';

exif(params.localPath, {}, arguments, function(err, obj) {
    // ...
})
```
