### PR TITLE
Changed exec for spawn, added better params handling & parsing multiple files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,8 @@ Image meta-information (EXIF, IPTC, XMP...) extraction using [exiftool](http://w
 
 __NOTE__: This fork from https://github.com/Yvem/node-exif has a DIFFERENT
 (improved !) API.
- Changed the implementation.
+
+ Mayor Changes:
  Instead of calling 'exiftool' through 'child_process.exec', it calls:
  [child_process.spawn](https://nodejs.org/api/child_process
    .html#child_process_child_process_spawn_command_args_options) which avoids buffer limitations.
@@ -22,15 +23,15 @@ __NOTE__: This fork from https://github.com/Yvem/node-exif has a DIFFERENT
  (http://www.sno.phy.queensu.ca/%7Ephil/exiftool/)
 
  Params:
+
    @param {String} file or path to folder
 
    @param {Array} args [optional] List of string arguments to pass to
    [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool/exiftool_pod.html)
 
    @param {Object} opts [optional] Object that is passed to the
-   child_process.spawn method as the `options` argument
-
-  See options of [child_process.spawn](https://nodejs.org/api/child_process
+   child_process.spawn method as the `options` argument. See options of
+   [child_process.spawn](https://nodejs.org/api/child_process
   .html#child_process_child_process_spawn_command_args_options)
 
   @param {function} fn callback function to invoke `fn(err, data)`
@@ -222,9 +223,9 @@ var exifParams = ['-FileName', '-ImageWidth', '-ImageHeight', '-Orientation',
   '-FileType', '-MIMEType'];
 
 exif(file, exifParams,  function(err, metadata){
-  console.log(metadata[0].['ImageWidth']); // 900
+  console.log(metadata[0].['ImageWidth']);  // 900
   console.log(metadata[0].['ImageHeight']); // 596
-  console.log(metadata[1].['ImageWidth']); // 3776
+  console.log(metadata[1].['ImageWidth']);  // 3776
   console.log(metadata[1].['ImageHeight']); // 3129
 
 }
@@ -267,7 +268,9 @@ See [child_process.spawn](https://nodejs.org/api/child_process
       .html#child_process_child_process_spawn_command_args_options)
 
 ### Special execution
-For special cases, it is possible to provide options for the spawn process.
+For special cases, it is possible to provide options for the [spawn process]
+(https://nodejs.org/api/child_process
+                                                                                .html#child_process_child_process_spawn_command_args_options).
 `exif()` optional third parameter may be an `spawn()` option object as
 described here:
 
@@ -289,6 +292,7 @@ npm test
 and also
 ```bash
 make test
+make bench
 ````
 
 ## License 

--- a/Readme.md
+++ b/Readme.md
@@ -269,8 +269,7 @@ See [child_process.spawn](https://nodejs.org/api/child_process
 
 ### Special execution
 For special cases, it is possible to provide options for the [spawn process]
-(https://nodejs.org/api/child_process
-                                                                                .html#child_process_child_process_spawn_command_args_options).
+(https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 `exif()` optional third parameter may be an `spawn()` option object as
 described here:
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,24 +2,48 @@
 
 Image meta-information (EXIF, IPTC, XMP...) extraction using [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool/)
 
-__NOTE__: This fork from https://github.com/visionmedia/node-exif has a DIFFERENT (improved !) API.
- It uses [precise tags](http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html) for field access.
+__NOTE__: This fork from https://github.com/Yvem/node-exif has a DIFFERENT
+(improved !) API.
+ Changed the implementation.
+ Instead of calling 'exiftool' through 'child_process.exec', it calls:
+ [child_process.spawn](https://nodejs.org/api/child_process
+   .html#child_process_child_process_spawn_command_args_options) which avoids buffer limitations.
+ It also allows to send specific arguments to the 'exiftool' shell command
+ and to read EXIF info from multiple files at once.
 
 ## Installation
 
-    $ npm install Yvem/node-exif
+    $ npm install jmunox/node-exif
 
 ## Usage
+
+ * Fetch EXIF data from `file` and invoke `fn(err, data)`.
+ It spawns a child process (see child_process.spawn) and executes [exiftool]
+ (http://www.sno.phy.queensu.ca/%7Ephil/exiftool/)
+
+ Params:
+   @param {String} file or path to folder
+
+   @param {Array} args [optional] List of string arguments to pass to
+   [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool/exiftool_pod.html)
+
+   @param {Object} opts [optional] Object that is passed to the
+   child_process.spawn method as the `options` argument
+
+  See options of [child_process.spawn](https://nodejs.org/api/child_process
+  .html#child_process_child_process_spawn_command_args_options)
+
+  @param {function} fn callback function to invoke `fn(err, data)`
 
 ```javascript
 var exif = require('exif2');
 
-exif(file, function(err, obj){
+exif(file, args, opts function(err, obj){
   console.log(obj);
 
   // see available tags http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html
-  console.log(o['FileName']);
-  console.log(o['Caption-Abstract']); // IPTC Caption [2,120]
+  console.log(obj['FileName']);
+  console.log(obj['Caption-Abstract']); // IPTC Caption [2,120]
 })
 ```
 
@@ -150,23 +174,109 @@ exif(file, function(err, obj){
 
 ## Advanced usage
 
-### Errors
-node-exif may throw custom errors :
-
-* `Metadata too big !` when metadata are too big to be parsed with current buffer limitations
-
-### Special options
-For special cases, it is possible to provide exec options.
-`exif()` optional second parameter may be an `exec()` option object as described here :
-http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
-
-Example usage : augment stdout buffer size to handle images with huge metadata :
+### Parsing specific TagNames
+It is possible to parse specific EXIF metadata from a file by defining the
+TagNames in the Arguments:
 
 ```javascript
-// REM : default buffer value is 200*1024
-exif(file, { maxBuffer: 1024*1024 }, function(err, obj) {
+var exif = require('exif2');
+var file = 'test/fixtures/forest.jpg';
+var exifParams = ['-FileName', '-ImageHeight', '-ImageWidth', '-Orientation',
+  '-DateTimeOriginal', '-CreateDate', '-ModifyDate', '-FileAccessDate',
+  '-FileType', '-MIMEType'];
+
+   exif(file, exifParams,  function(err, metadata){
+
+     console.log(metadata.['ImageHeight']);
+     console.log(metadata.['ImageWidth']);
+   }
+
+```
+
+```json
+{
+	"SourceFile": "test/fixtures/forest.jpeg",
+	"FileName": "forest.jpeg",
+	"ImageWidth": 900,
+    "ImageHeight": 596
+    "Orientation": "Horizontal (normal)",
+	"DateTimeOriginal": "2012:10:07 11:36:30",
+    "CreateDate": "2012:10:07 11:36:30",
+    "ModifyDate": "2012:10:08 19:10:63",
+	"FileAccessDate": "2014:03:24 15:27:05+01:00",
+	"FileType": "JPEG",
+	"MIMEType": "image/jpeg"
+}
+```
+
+### Parsing EXIF from several media files in path
+It is also possible to parse EXIF metadata from all the media file by setting
+ the path to a specific folder. The data is returned in an Array. This is
+ more efficient, instead of calling `exif` for each file in the folder.
+
+```javascript
+var exif = require('exif2');
+var path = 'test/fixtures/';
+var exifParams = ['-FileName', '-ImageWidth', '-ImageHeight', '-Orientation',
+  '-DateTimeOriginal', '-CreateDate', '-ModifyDate', '-FileAccessDate',
+  '-FileType', '-MIMEType'];
+
+exif(file, exifParams,  function(err, metadata){
+  console.log(metadata[0].['ImageWidth']); // 900
+  console.log(metadata[0].['ImageHeight']); // 596
+  console.log(metadata[1].['ImageWidth']); // 3776
+  console.log(metadata[1].['ImageHeight']); // 3129
+
+}
+```
+Result:
+```json
+[{
+	"SourceFile": "test/fixtures/forest.jpeg",
+    "FileName": "forest.jpeg",
+	"ImageWidth": 900,
+	"ImageHeight": 596,
+    "Orientation": "Horizontal (normal)",
+	"DateTimeOriginal": "2012:10:07 11:36:30",
+    "CreateDate": "2012:10:07 11:36:30",
+    "ModifyDate": "2012:10:08 19:10:63",
+	"FileAccessDate": "2014:03:24 15:27:05+01:00",
+	"FileType": "JPEG",
+	"MIMEType": "image/jpeg"
+},
+{
+    "SourceFile": "test/fixtures/le_livre_de_photographies_vol_III_Phaidon.jpg",
+    "FileName": "le_livre_de_photographies_vol_III_Phaidon.jpg",
+    "ImageWidth": 3776,
+    "ImageHeight": 3129,
+    "Orientation": "Horizontal (normal)",
+    "CreateDate": "2014:01:09 12:52:13+01:00",
+    "ModifyDate": "2014:01:09 15:36:23",
+    "FileAccessDate": "2016:10:31 16:24:05+01:00",
+    "FileType": "JPEG",
+    "MIMEType": "image/jpeg"
+}]
+```
+### No more known buffer limitation
+
+Since this version uses `child_process.spawn()` instead of
+`child_process.exec()`, the output is handled in a different way, avoiding
+buffer limitations.
+
+See [child_process.spawn](https://nodejs.org/api/child_process
+      .html#child_process_child_process_spawn_command_args_options)
+
+### Special execution
+For special cases, it is possible to provide options for the spawn process.
+`exif()` optional third parameter may be an `spawn()` option object as
+described here:
+
+```javascript
+var opts = { cwd: undefined, env: process.env };
+exif(file, args, opts, function(err, obj) {
   console.log(obj);
 })
+
 ```
 
 ## Test / contribute
@@ -179,7 +289,6 @@ npm test
 and also
 ```bash
 make test
-make bench
 ````
 
 ## License 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "exif2",
-  "version": "1.1.0",
+  "name": "@jmunox/exif2",
+  "version": "1.3.0",
   "description": "EXIF extraction with exiftool",
   "keywords": [],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,20 @@
   "main": "index",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Yvem/node-exif.git"
+    "url": "https://github.com/jmunox/node-exif.git"
   },
   "scripts": {
     "test": "mocha test/index.js --reporter spec",
     "bench": "matcha bench/index.js"
-  }
+  },
+  "contributors": [
+    {
+      "name": "Yves-Emmanuel Jutard",
+      "email": "ye.jutard@gmail.com"
+    },
+    {
+      "name": "Jesús Muñoz Alcántara",
+      "email": "jmunoza@live.com"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jmunox/node-exif.git"
+    "url": "https://github.com/Yvem/node-exif.git"
   },
   "scripts": {
     "test": "mocha test/index.js --reporter spec",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jmunox/exif2",
+  "name": "exif2",
   "version": "1.3.0",
   "description": "EXIF extraction with exiftool",
   "keywords": [],

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var chai = require('chai');
 var expect = chai.expect;
 chai.config.includeStack = true; // defaults to false
 
-describe('exif(file, fn)', function(){
+describe('exif(file[, args, opts,] fn)', function(){
 
   it('respond with EXIF json data', function(done){
     exif('test/fixtures/forest.jpeg', function(err, data){
@@ -25,24 +25,62 @@ describe('exif(file, fn)', function(){
     });
   });
 
-  it('handles too big metadata with a clear error message', function(done){
-    // real case taken from :
-    // http://fr.phaidon.com/store/photography/le-livre-de-photographies-une-histoire-vol-3-9780714867755/
-    exif('test/fixtures/le_livre_de_photographies_vol_III_Phaidon.jpg', function(err){
-      expect( err ).to.be.an.instanceof(Error);
-      expect( err ).to.have.property('message', 'Metadata too big !');
+  it('extracts specific EXIF data defined in arguments', function(done){
+    exif('test/fixtures/forest.jpeg', ['-d', '\'%r %a, %B %e, %Y\'', '-DateTimeOriginal',
+      '-S', '-s'], function(err, data) {
+      if (err) return done(err);
+      expect(data, 'DateTimeOriginal').to.have.property('DateTimeOriginal', '\'11:36:30 AM Sun, October  7, 2012\'');
       done();
     });
   });
 
-  it('allows handling huge metadatas through special options', function(done){
-    // we use the special exec option to ease limitations
-    exif('test/fixtures/le_livre_de_photographies_vol_III_Phaidon.jpg', {
-      maxBuffer: 1024*1024
-    },
+  it('handles too big metadata without buffer errors', function(done){
+    // real case taken from :
+    // http://fr.phaidon.com/store/photography/le-livre-de-photographies-une-histoire-vol-3-9780714867755/
+    exif('test/fixtures/le_livre_de_photographies_vol_III_Phaidon.jpg', function(err, data){
+      if(err) return done(err);
+      expect(data).to.have.property('YCbCrSubSampling', 'YCbCr4:4:4 (1 1)');
+      done();
+    });
+  });
+
+  it('handles all media files contained in the folder at once', function(done){
+    exif('test/fixtures/', function(err, data) {
+      if (err) return done(err);
+      expect(data[0], 'FileName').to.have.property('FileName', 'forest.jpeg');
+      expect(data[1], 'FileName').to.have.property('FileName', 'le_livre_de_photographies_vol_III_Phaidon.jpg');
+      done();
+    });
+  });
+
+  it('handles all media files contained in the path plus arguments', function(done){
+    exif('test/fixtures/', ['-common'], function(err, data) {
+      if (err) return done(err);
+      expect(data[0], 'Model').to.have.property('Model', 'NIKON D7000');
+      expect(data[1], 'ImageSize').to.have.property('ImageSize', '3129x3776');
+      done();
+    });
+  });
+
+  it('get specified info from all media files contained in the path', function(done){
+    exif('test/fixtures/', ['-ExifImageWidth', '-Megapixels'], function(err, data) {
+      if (err) return done(err);
+      expect(data[0], 'ExifImageWidth').to.have.property('ExifImageWidth', 1971);
+      expect(data[0], 'Megapixels').to.have.property('Megapixels', 0.536);
+      expect(data[0], 'ExifImageHeight').to.not.have.property('ExifImageHeight');
+      expect(data[1], 'ExifImageWidth').to.have.property('ExifImageWidth', 3129);
+      expect(data[1], 'Megapixels').to.have.property('Megapixels', 11.8);
+      expect(data[1], 'ExifImageHeight').to.not.have.property('ExifImageHeight');
+      done();
+    });
+  });
+
+  it('handles all media files in path plus arguments plus spawn options', function(done){
+    exif('test/fixtures/', ['-common'], { cwd: undefined, env: process.env },
     function(err, data) {
       if (err) return done(err);
-      expect(data).to.have.property('YCbCrSubSampling', 'YCbCr4:4:4 (1 1)');
+      expect(data[0], 'Model').to.have.property('Model', 'NIKON D7000');
+      expect(data[1], 'ImageSize').to.have.property('ImageSize', '3129x3776');
       done();
     });
   });


### PR DESCRIPTION
Hi Yves,

I made some changes on the code.

1) Instead of calling 'exiftool' through 'child_process.exec', it calls: child_process.spawn which avoids buffer limitations. 

2) It also allows to send specific arguments to the 'exiftool' shell command 

3) It can read EXIF info from multiple files at once by calling the path to a folder instead of a file

You can check on https://github.com/jmunox/node-exif

Cheers

Jesus